### PR TITLE
Create host and player front-end dashboards

### DIFF
--- a/public/host.html
+++ b/public/host.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Tableau animateur · Beta Boardgame</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <header class="header">
+      <div>
+        <h1 class="header__title">Espace Animateur</h1>
+        <div class="header__meta">
+          <span class="chip">Code session <strong id="session-code">—</strong></span>
+          <span class="chip">Mode <strong id="session-mode">—</strong></span>
+          <span class="chip">Tour <strong id="session-turn">—</strong></span>
+          <span class="chip">Phase <strong id="session-phase">—</strong></span>
+        </div>
+      </div>
+      <div class="profile-strip" id="session-actions">
+        <button class="secondary" id="copy-code" type="button" disabled>Copier le code</button>
+        <button class="primary" id="start-game" type="button" disabled>Démarrer la partie</button>
+        <button class="secondary" id="next-turn" type="button" disabled>Tour suivant</button>
+      </div>
+    </header>
+
+    <main>
+      <div class="layout">
+        <div class="column">
+          <section class="card">
+            <div class="section-title">
+              <h2>Configuration</h2>
+              <span class="chip" id="config-status">En attente</span>
+            </div>
+            <form class="form-grid" id="session-form">
+              <label>Mode de jeu
+                <select name="mode" required>
+                  <option value="long" selected>Long</option>
+                  <option value="blitz">Blitz</option>
+                </select>
+              </label>
+              <label>Langue
+                <select name="lang" required>
+                  <option value="fr" selected>Français</option>
+                </select>
+              </label>
+              <label>Rejoindre une session existante
+                <input type="text" name="code" placeholder="Code (facultatif)" autocomplete="off" maxlength="5" />
+              </label>
+              <button class="primary" type="submit">Créer ou rejoindre</button>
+            </form>
+          </section>
+
+          <section class="card">
+            <div class="section-title">
+              <h2>Joueurs connectés</h2>
+              <span class="chip" id="player-count">0 joueur</span>
+            </div>
+            <div class="player-list" id="player-list"></div>
+          </section>
+        </div>
+
+        <div class="column">
+          <section class="card">
+            <div id="midgame-banner" class="midgame-banner">Pause intermédiaire recommandée.</div>
+            <div class="timer-panel">
+              <div class="timer-ring" id="timer-ring"><span id="timer-value">--:--</span></div>
+              <p id="timer-status">Timer en attente</p>
+              <div class="progress-bar" aria-hidden="true"><span id="timer-progress"></span></div>
+            </div>
+          </section>
+
+          <section class="card">
+            <div class="section-title">
+              <h2>Cartes communes</h2>
+              <span class="chip" id="card-refresh">—</span>
+            </div>
+            <div class="cards-grid" id="common-cards"></div>
+            <details style="margin-top:16px;">
+              <summary>Historique des tirages</summary>
+              <div class="timeline" id="draw-history"></div>
+            </details>
+          </section>
+
+          <section class="card">
+            <div class="section-title">
+              <h2>Journal global</h2>
+              <span class="chip" id="journal-count">0 entrée</span>
+            </div>
+            <div class="timeline" id="global-journal"></div>
+          </section>
+        </div>
+
+        <div class="column">
+          <section class="card">
+            <div class="section-title">
+              <h2>Tableau des joueurs</h2>
+              <span class="chip">Analyses en direct</span>
+            </div>
+            <div class="player-list" id="player-analytics"></div>
+          </section>
+
+          <section class="card">
+            <div class="section-title">
+              <h2>Notifications</h2>
+              <span class="chip">Temps réel</span>
+            </div>
+            <div class="timeline" id="event-log"></div>
+          </section>
+        </div>
+      </div>
+    </main>
+
+    <div class="toast-container" id="toast-container"></div>
+
+    <script src="/socket.io/socket.io.js"></script>
+    <script type="module" src="/host.js"></script>
+  </body>
+</html>

--- a/public/host.js
+++ b/public/host.js
@@ -1,0 +1,567 @@
+const els = {
+  sessionCode: document.querySelector('#session-code'),
+  sessionMode: document.querySelector('#session-mode'),
+  sessionTurn: document.querySelector('#session-turn'),
+  sessionPhase: document.querySelector('#session-phase'),
+  copyCode: document.querySelector('#copy-code'),
+  startGame: document.querySelector('#start-game'),
+  nextTurn: document.querySelector('#next-turn'),
+  configStatus: document.querySelector('#config-status'),
+  playerCount: document.querySelector('#player-count'),
+  playerList: document.querySelector('#player-list'),
+  playerAnalytics: document.querySelector('#player-analytics'),
+  sessionForm: document.querySelector('#session-form'),
+  commonCards: document.querySelector('#common-cards'),
+  drawHistory: document.querySelector('#draw-history'),
+  journalCount: document.querySelector('#journal-count'),
+  globalJournal: document.querySelector('#global-journal'),
+  eventLog: document.querySelector('#event-log'),
+  timerRing: document.querySelector('#timer-ring'),
+  timerValue: document.querySelector('#timer-value'),
+  timerStatus: document.querySelector('#timer-status'),
+  timerProgress: document.querySelector('#timer-progress'),
+  cardRefresh: document.querySelector('#card-refresh'),
+  midgameBanner: document.querySelector('#midgame-banner'),
+  toastContainer: document.querySelector('#toast-container'),
+};
+
+let sessionCode = null;
+let socket = null;
+let lastState = null;
+let lastTimerTick = null;
+
+function showToast(title, message) {
+  const toast = document.createElement('div');
+  toast.className = 'toast';
+  toast.innerHTML = `<strong>${title}</strong><p>${message}</p>`;
+  els.toastContainer.appendChild(toast);
+  setTimeout(() => {
+    toast.style.opacity = '0';
+    toast.style.transform = 'translateY(8px)';
+  }, 3800);
+  setTimeout(() => toast.remove(), 4600);
+}
+
+function formatDateTime(ts) {
+  const d = new Date(ts);
+  return `${d.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit', second: '2-digit' })}`;
+}
+
+function formatRelative(ts) {
+  if (!ts) return '—';
+  const diff = Date.now() - ts;
+  if (diff < 1000) return 'À l'instant';
+  const min = Math.floor(diff / 60000);
+  if (min < 1) return 'Il y a quelques secondes';
+  if (min === 1) return 'Il y a une minute';
+  if (min < 60) return `Il y a ${min} min`;
+  const h = Math.floor(min / 60);
+  return `Il y a ${h} h`;
+}
+
+function computeManualPhase(state) {
+  if (!state) return false;
+  const turn = (state.turnIndex || 0) + 1;
+  return turn <= state.hostControls.manualUntilTurn || turn >= state.hostControls.manualLastTurnsFrom;
+}
+
+function updateHeader(state) {
+  els.sessionCode.textContent = state?.code ?? '—';
+  els.sessionMode.textContent = state?.mode ?? '—';
+  const turn = state ? `${state.turnIndex + 1} / ${state.totalTurns}` : '—';
+  els.sessionTurn.textContent = turn;
+  els.sessionPhase.textContent = state?.phase ?? '—';
+
+  els.configStatus.textContent = state ? (state.phase === 'SETUP' ? 'Configuration' : 'En cours') : 'En attente';
+  els.copyCode.disabled = !sessionCode;
+  els.startGame.disabled = !sessionCode || !state || state.phase !== 'SETUP';
+  els.nextTurn.disabled = !sessionCode || !state || state.phase !== 'PLAY' || !computeManualPhase(state);
+}
+
+function renderPlayers(players = []) {
+  els.playerList.innerHTML = '';
+  if (!players.length) {
+    const empty = document.createElement('p');
+    empty.textContent = 'Aucun joueur connecté pour le moment.';
+    els.playerList.appendChild(empty);
+  }
+
+  players.forEach((player, idx) => {
+    const card = document.createElement('div');
+    card.className = 'player-card';
+
+    const avatar = document.createElement('div');
+    avatar.className = 'avatar';
+    const name = player.profile?.name || `Joueur ${idx + 1}`;
+    avatar.textContent = (name || '').slice(0, 2).toUpperCase();
+
+    const info = document.createElement('div');
+    const title = document.createElement('strong');
+    title.textContent = name;
+    title.style.display = 'block';
+    title.style.fontSize = '0.95rem';
+    title.style.marginBottom = '4px';
+
+    const badges = document.createElement('div');
+    badges.className = 'badge-line';
+    const decisionBadge = document.createElement('span');
+    decisionBadge.className = 'badge';
+    decisionBadge.textContent = player.decision ? `Décision: ${player.decision === 'accept' ? 'Accepte' : 'Refuse'}` : 'En réflexion';
+    badges.appendChild(decisionBadge);
+
+    const incomeBadge = document.createElement('span');
+    incomeBadge.className = 'badge';
+    incomeBadge.textContent = 'Revenus';
+    if (player.decision === 'accept') incomeBadge.classList.add('active');
+    badges.appendChild(incomeBadge);
+
+    const expenseBadge = document.createElement('span');
+    expenseBadge.className = 'badge';
+    expenseBadge.textContent = 'Dépenses';
+    if (player.decision === 'reject') expenseBadge.classList.add('active');
+    badges.appendChild(expenseBadge);
+
+    const ready = document.createElement('span');
+    ready.className = `status-pill ${player.ready ? 'ready' : ''}`;
+    ready.textContent = player.ready ? 'Prêt' : 'En cours';
+
+    const locked = document.createElement('span');
+    locked.className = `status-pill ${player.locked ? 'locked' : ''}`;
+    locked.textContent = player.locked ? 'Verrouillé' : 'Ouvert';
+
+    info.appendChild(title);
+    info.appendChild(badges);
+
+    const statusCol = document.createElement('div');
+    statusCol.style.display = 'grid';
+    statusCol.style.justifyItems = 'end';
+    statusCol.style.gap = '6px';
+    statusCol.appendChild(ready);
+    statusCol.appendChild(locked);
+
+    card.appendChild(avatar);
+    card.appendChild(info);
+    card.appendChild(statusCol);
+    els.playerList.appendChild(card);
+  });
+
+  els.playerCount.textContent = `${players.length} ${players.length > 1 ? 'joueurs' : 'joueur'}`;
+}
+
+function buildPlayerTimeline(entries, playerId) {
+  return entries.filter(e => e.playerId === playerId);
+}
+
+function drawSparkline(canvas, points) {
+  const ctx = canvas.getContext('2d');
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = 'rgba(31, 111, 235, 0.85)';
+  ctx.beginPath();
+  const margin = 6;
+  const width = canvas.width - margin * 2;
+  const height = canvas.height - margin * 2;
+  if (!points.length) {
+    ctx.moveTo(margin, canvas.height / 2);
+    ctx.lineTo(canvas.width - margin, canvas.height / 2);
+  } else {
+    points.forEach((val, idx) => {
+      const x = margin + (idx / Math.max(points.length - 1, 1)) * width;
+      const norm = (val + 1) / 2;
+      const y = margin + (1 - norm) * height;
+      if (idx === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    });
+  }
+  ctx.stroke();
+
+  ctx.fillStyle = 'rgba(199, 220, 255, 0.5)';
+  points.forEach((val, idx) => {
+    const x = margin + (idx / Math.max(points.length - 1, 1)) * width;
+    const norm = (val + 1) / 2;
+    const y = margin + (1 - norm) * height;
+    ctx.beginPath();
+    ctx.arc(x, y, 3, 0, Math.PI * 2);
+    ctx.fill();
+  });
+}
+
+function renderPlayerAnalytics(players = [], journal = []) {
+  els.playerAnalytics.innerHTML = '';
+  const decisionScores = new Map();
+  journal.forEach(entry => {
+    if (entry.type === 'PLAYER_DECISION_EVENT') {
+      const score = decisionScores.get(entry.playerId) || [];
+      score.push(entry.decision === 'accept' ? 1 : -1);
+      decisionScores.set(entry.playerId, score);
+    }
+    if (entry.type === 'PLAYER_READY') {
+      const score = decisionScores.get(entry.playerId) || [];
+      score.push(0);
+      decisionScores.set(entry.playerId, score);
+    }
+  });
+
+  players.forEach((player, idx) => {
+    const card = document.createElement('div');
+    card.className = 'player-card';
+
+    const avatar = document.createElement('div');
+    avatar.className = 'avatar';
+    const name = player.profile?.name || `Joueur ${idx + 1}`;
+    avatar.textContent = (name || '').slice(0, 2).toUpperCase();
+
+    const info = document.createElement('div');
+    info.className = 'player-analytics';
+
+    const header = document.createElement('div');
+    const strong = document.createElement('strong');
+    strong.textContent = name;
+    header.appendChild(strong);
+    const subtitle = document.createElement('span');
+    subtitle.style.color = 'rgba(199, 220, 255, 0.7)';
+    subtitle.style.fontSize = '0.8rem';
+    subtitle.textContent = player.profile?.key ? `Profil · ${player.profile.key}` : `ID ${player.id.slice(0, 4)}`;
+    header.appendChild(document.createElement('br'));
+    header.appendChild(subtitle);
+
+    const badges = document.createElement('div');
+    badges.className = 'badge-line';
+
+    const childBadge = document.createElement('span');
+    childBadge.className = 'badge';
+    childBadge.textContent = '👶 Enfants';
+    if (/enfant|famille/i.test(name)) childBadge.classList.add('active');
+    badges.appendChild(childBadge);
+
+    const financeBadge = document.createElement('span');
+    financeBadge.className = 'badge';
+    financeBadge.textContent = '💰 Revenus';
+    if (player.decision === 'accept') financeBadge.classList.add('active');
+    badges.appendChild(financeBadge);
+
+    const expenseBadge = document.createElement('span');
+    expenseBadge.className = 'badge';
+    expenseBadge.textContent = '📉 Dépenses';
+    if (player.decision === 'reject') expenseBadge.classList.add('active');
+    badges.appendChild(expenseBadge);
+
+    const timeline = buildPlayerTimeline(journal, player.id);
+    const decisions = decisionScores.get(player.id) || [];
+
+    const canvas = document.createElement('canvas');
+    canvas.width = 160;
+    canvas.height = 50;
+    canvas.className = 'sparkline';
+    drawSparkline(canvas, decisions);
+
+    const list = document.createElement('div');
+    list.className = 'timeline-small';
+    timeline.slice(-4).reverse().forEach(entry => {
+      const item = document.createElement('div');
+      item.className = 'item';
+      const title = document.createElement('h4');
+      title.textContent = `${entry.type.replace('PLAYER_', '')} · ${formatDateTime(entry.at)}`;
+      const body = document.createElement('p');
+      if (entry.type === 'PLAYER_DECISION_EVENT') {
+        body.textContent = entry.decision === 'accept' ? 'Décision positive (revenus)' : 'Décision négative (dépenses)';
+      } else if (entry.type === 'PLAYER_READY') {
+        body.textContent = 'Statut changé en prêt';
+      } else if (entry.type === 'PLAYER_LOCK') {
+        body.textContent = 'Décision verrouillée';
+      } else {
+        body.textContent = JSON.stringify(entry);
+      }
+      item.appendChild(title);
+      item.appendChild(body);
+      list.appendChild(item);
+    });
+
+    info.appendChild(header);
+    info.appendChild(badges);
+    info.appendChild(canvas);
+    info.appendChild(list);
+
+    const statusCol = document.createElement('div');
+    statusCol.style.display = 'grid';
+    statusCol.style.gap = '6px';
+    statusCol.style.justifyItems = 'end';
+
+    const ready = document.createElement('span');
+    ready.className = `status-pill ${player.ready ? 'ready' : ''}`;
+    ready.textContent = player.ready ? 'Prêt' : 'En cours';
+    const locked = document.createElement('span');
+    locked.className = `status-pill ${player.locked ? 'locked' : ''}`;
+    locked.textContent = player.locked ? 'Verrouillé' : 'Ouvert';
+    statusCol.appendChild(ready);
+    statusCol.appendChild(locked);
+
+    card.appendChild(avatar);
+    card.appendChild(info);
+    card.appendChild(statusCol);
+    els.playerAnalytics.appendChild(card);
+  });
+}
+
+function renderCommonCards(draw) {
+  els.commonCards.innerHTML = '';
+  if (!draw) {
+    const empty = document.createElement('p');
+    empty.textContent = 'Les cartes apparaîtront dès le premier tour.';
+    els.commonCards.appendChild(empty);
+    return;
+  }
+  Object.entries(draw).forEach(([type, card]) => {
+    const node = document.createElement('article');
+    node.className = 'common-card';
+    node.dataset.type = type;
+    const title = document.createElement('h3');
+    title.textContent = card.title;
+    const category = document.createElement('span');
+    category.className = 'category';
+    category.textContent = card.category || type;
+    const slug = document.createElement('p');
+    slug.className = 'slug';
+    slug.textContent = card.slug || '—';
+    node.appendChild(category);
+    node.appendChild(title);
+    node.appendChild(slug);
+    els.commonCards.appendChild(node);
+  });
+}
+
+function describeEntry(entry) {
+  switch (entry.type) {
+    case 'SESSION_CREATED':
+      return 'Session créée';
+    case 'GAME_STARTED':
+      return 'Partie démarrée';
+    case 'TURN_STARTED':
+      return `Tour ${entry.turn} démarré`;
+    case 'TURN_ENDED':
+      return `Tour ${entry.turn} terminé`;
+    case 'PLAYER_READY':
+      return `Joueur ${entry.playerId.slice(0, 4)} prêt`;
+    case 'PLAYER_DECISION_EVENT':
+      return `Joueur ${entry.playerId.slice(0, 4)} ${entry.decision === 'accept' ? 'accepte' : 'refuse'}`;
+    case 'PLAYER_LOCK':
+      return `Joueur ${entry.playerId.slice(0, 4)} verrouille sa décision`;
+    case 'HOST_KICK':
+      return `Joueur ${entry.playerId.slice(0, 4)} retiré`;
+    case 'GAME_ENDED':
+      return 'Partie terminée';
+    case 'HOST_CORRECTION':
+      return `Correction de l'action ${entry.targetActionId}`;
+    default:
+      return entry.type;
+  }
+}
+
+function renderJournal(journal = []) {
+  els.globalJournal.innerHTML = '';
+  journal.slice().reverse().forEach(entry => {
+    const node = document.createElement('div');
+    node.className = 'timeline-entry';
+    const title = document.createElement('h4');
+    title.textContent = `${formatDateTime(entry.at)} · ${entry.type}`;
+    const body = document.createElement('p');
+    body.textContent = describeEntry(entry);
+    node.appendChild(title);
+    node.appendChild(body);
+    els.globalJournal.appendChild(node);
+  });
+  els.journalCount.textContent = `${journal.length} entrée${journal.length > 1 ? 's' : ''}`;
+}
+
+function renderDrawHistory(journal = []) {
+  els.drawHistory.innerHTML = '';
+  const draws = journal.filter(e => e.type === 'TURN_STARTED' && e.draw);
+  if (!draws.length) {
+    const empty = document.createElement('p');
+    empty.textContent = 'Pas encore d\'historique.';
+    els.drawHistory.appendChild(empty);
+    return;
+  }
+  draws.slice().reverse().forEach(entry => {
+    const node = document.createElement('div');
+    node.className = 'timeline-entry';
+    const title = document.createElement('h4');
+    title.textContent = `Tour ${entry.turn} · ${formatDateTime(entry.at)}`;
+    const list = document.createElement('p');
+    const cards = Object.entries(entry.draw).map(([key, card]) => `${key}: ${card.title}`);
+    list.textContent = cards.join(' · ');
+    node.appendChild(title);
+    node.appendChild(list);
+    els.drawHistory.appendChild(node);
+  });
+}
+
+function updateTimer(now, reminderAt, endsAt) {
+  if (!reminderAt || !endsAt) {
+    els.timerValue.textContent = '--:--';
+    els.timerStatus.textContent = 'Timer en attente';
+    els.timerRing.style.setProperty('--timer-progress', '0%');
+    els.timerProgress.style.setProperty('--progress', 0);
+    return;
+  }
+  const start = reminderAt - (3 * 60 * 1000);
+  const total = endsAt - start;
+  const remaining = Math.max(0, endsAt - now);
+  const mins = Math.floor(remaining / 60000);
+  const secs = Math.floor((remaining % 60000) / 1000).toString().padStart(2, '0');
+  els.timerValue.textContent = `${mins}:${secs}`;
+
+  const progress = Math.min(1, Math.max(0, (now - start) / total));
+  els.timerRing.style.setProperty('--timer-progress', `${progress * 100}%`);
+  els.timerProgress.style.setProperty('--progress', progress);
+
+  if (remaining <= 0) {
+    els.timerStatus.textContent = 'Tour terminé automatiquement';
+    els.timerRing.style.setProperty('--timer-progress', '100%');
+    els.timerProgress.style.setProperty('--progress', 1);
+    return;
+  }
+
+  if (now >= reminderAt) {
+    els.timerStatus.textContent = 'Phase de grâce';
+    els.timerRing.style.setProperty('--timer-progress', `${progress * 100}%`);
+    els.timerRing.style.background = `conic-gradient(var(--danger) ${progress * 100}%, rgba(199,220,255,0.12) 0)`;
+  } else {
+    els.timerStatus.textContent = 'Tour en cours';
+    els.timerRing.style.background = `conic-gradient(var(--navy-300) ${progress * 100}%, rgba(199,220,255,0.12) 0)`;
+  }
+}
+
+function applyState(state) {
+  lastState = state;
+  updateHeader(state);
+  renderPlayers(state.players);
+  renderPlayerAnalytics(state.players, state.journal || []);
+  renderCommonCards(state.commonDraw);
+  renderJournal(state.journal || []);
+  renderDrawHistory(state.journal || []);
+  els.cardRefresh.textContent = state.commonDraw ? `Mis à jour ${formatRelative(state.lastUpdateAt)}` : 'En attente de tirage';
+}
+
+function connectSocket(code) {
+  if (socket) {
+    socket.disconnect();
+  }
+  socket = io({ path: '/ws' });
+  socket.emit('JOIN_SESSION', { code });
+
+  socket.on('SESSION_UPDATED', payload => {
+    if (payload && payload.kind) {
+      showToast('Notification', payload.msg || 'Mise à jour');
+      const log = document.createElement('div');
+      log.className = 'timeline-entry';
+      const title = document.createElement('h4');
+      title.textContent = `${new Date().toLocaleTimeString()} · ${payload.kind}`;
+      const body = document.createElement('p');
+      body.textContent = payload.msg || '';
+      log.appendChild(title);
+      log.appendChild(body);
+      els.eventLog.prepend(log);
+      return;
+    }
+    applyState(payload);
+  });
+
+  socket.on('TIMER_TICK', data => {
+    lastTimerTick = data;
+    updateTimer(data.now, data.reminderAt, data.endsAt);
+  });
+
+  socket.on('TURN_STARTED', data => {
+    showToast('Nouveau tour', `Tour ${data.turn} lancé`);
+  });
+
+  socket.on('TURN_ENDED', data => {
+    showToast('Fin de tour', `Tour ${data.turn} terminé`);
+  });
+
+  socket.on('MIDGAME_BREAK', data => {
+    els.midgameBanner.classList.add('active');
+    showToast('Pause recommandée', `Tour ${data.turn}`);
+  });
+
+  socket.on('ERROR', data => {
+    showToast('Erreur', data.error || 'Action impossible');
+  });
+}
+
+async function fetchState(code) {
+  const res = await fetch(`/session/${code}/state`);
+  if (!res.ok) {
+    throw new Error('Session introuvable');
+  }
+  const json = await res.json();
+  applyState(json);
+}
+
+function setSession(code) {
+  sessionCode = code;
+  els.sessionCode.textContent = code;
+  els.copyCode.disabled = !code;
+  if (code) {
+    connectSocket(code);
+    fetchState(code).catch(err => showToast('Erreur', err.message));
+  }
+}
+
+els.copyCode.addEventListener('click', async () => {
+  if (!sessionCode) return;
+  try {
+    await navigator.clipboard.writeText(sessionCode);
+    showToast('Copié', 'Le code a été copié dans le presse-papiers.');
+  } catch (err) {
+    showToast('Impossible de copier', sessionCode);
+  }
+});
+
+els.startGame.addEventListener('click', () => {
+  if (!sessionCode || !socket) return;
+  socket.emit('HOST_START', { code: sessionCode });
+});
+
+els.nextTurn.addEventListener('click', () => {
+  if (!sessionCode || !socket) return;
+  socket.emit('HOST_NEXT_TURN', { code: sessionCode });
+});
+
+els.sessionForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const form = new FormData(event.currentTarget);
+  const mode = form.get('mode');
+  const lang = form.get('lang');
+  const manualCode = (form.get('code') || '').trim().toUpperCase();
+  if (manualCode) {
+    setSession(manualCode);
+    return;
+  }
+  try {
+    const res = await fetch('/session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mode, lang }),
+    });
+    if (!res.ok) {
+      const payload = await res.json().catch(() => ({}));
+      throw new Error(payload.error || 'Création impossible');
+    }
+    const json = await res.json();
+    setSession(json.code);
+    showToast('Session créée', `Code ${json.code}`);
+  } catch (err) {
+    showToast('Erreur', err.message);
+  }
+});
+
+setInterval(() => {
+  if (lastState) {
+    els.cardRefresh.textContent = lastState.commonDraw ? `Mis à jour ${formatRelative(lastState.lastUpdateAt)}` : 'En attente de tirage';
+  }
+  if (lastTimerTick) {
+    updateTimer(Date.now(), lastTimerTick.reminderAt, lastTimerTick.endsAt);
+  }
+}, 5000);

--- a/public/player.html
+++ b/public/player.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Espace joueur · Beta Boardgame</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <header class="header">
+      <div>
+        <h1 class="header__title">Espace Joueur</h1>
+        <div class="header__meta">
+          <span class="chip">Code <strong id="player-session-code">—</strong></span>
+          <span class="chip">Tour <strong id="player-turn">—</strong></span>
+          <span class="chip">Statut <strong id="player-status">Hors ligne</strong></span>
+        </div>
+      </div>
+      <div class="profile-strip">
+        <span class="profile-chip" id="player-profile">Profil non défini</span>
+        <button class="secondary" id="leave-session" type="button" disabled>Quitter</button>
+      </div>
+    </header>
+
+    <main>
+      <div class="layout">
+        <div class="column">
+          <section class="card" id="join-card">
+            <div class="section-title">
+              <h2>Rejoindre une partie</h2>
+              <span class="chip">Connexion sécurisée</span>
+            </div>
+            <form class="form-grid" id="join-form">
+              <label>Code
+                <input type="text" name="code" placeholder="ABCDE" maxlength="5" required />
+              </label>
+              <label>Nom ou pseudo
+                <input type="text" name="name" placeholder="Votre nom" />
+              </label>
+              <button class="primary" type="submit">Rejoindre</button>
+            </form>
+          </section>
+
+          <section class="card">
+            <div class="section-title">
+              <h2>Cartes du tour</h2>
+              <span class="chip" id="player-card-refresh">—</span>
+            </div>
+            <div class="cards-grid" id="player-common-cards"></div>
+          </section>
+
+          <section class="card">
+            <div class="section-title">
+              <h2>Notes personnelles</h2>
+              <span class="chip">Privé</span>
+            </div>
+            <div class="note-area">
+              <textarea id="player-notes" placeholder="Écrivez vos décisions, idées ou calculs."></textarea>
+            </div>
+          </section>
+        </div>
+
+        <div class="column">
+          <section class="card">
+            <div id="player-midgame" class="midgame-banner">Pause intermédiaire reçue.</div>
+            <div class="timer-panel">
+              <div class="timer-ring" id="player-timer-ring"><span id="player-timer-value">--:--</span></div>
+              <p id="player-timer-status">En attente du lancement</p>
+              <div class="progress-bar"><span id="player-timer-progress"></span></div>
+            </div>
+          </section>
+
+          <section class="card">
+            <div class="section-title">
+              <h2>Vos actions</h2>
+              <span class="chip">Décision rapide</span>
+            </div>
+            <div class="player-action-bar">
+              <button class="accept" id="action-accept" type="button" disabled>Accepter</button>
+              <button class="reject" id="action-reject" type="button" disabled>Refuser</button>
+              <button class="lock" id="action-lock" type="button" disabled>Verrouiller ma décision</button>
+              <button class="secondary" id="action-ready" type="button" disabled>Je suis prêt</button>
+            </div>
+          </section>
+
+          <section class="card">
+            <div class="section-title">
+              <h2>Journal personnel</h2>
+              <span class="chip" id="player-journal-count">0 entrée</span>
+            </div>
+            <div class="timeline" id="player-journal"></div>
+          </section>
+        </div>
+
+        <div class="column">
+          <section class="card">
+            <div class="section-title">
+              <h2>Équipe connectée</h2>
+              <span class="chip" id="player-team-count">0 joueur</span>
+            </div>
+            <div class="player-list" id="player-team"></div>
+          </section>
+
+          <section class="card">
+            <div class="section-title">
+              <h2>Statistiques rapides</h2>
+              <span class="chip">Décisions</span>
+            </div>
+            <div class="mini-grid">
+              <div class="mini-metric">
+                <h4>Décisions prises</h4>
+                <strong id="metric-decisions">0</strong>
+              </div>
+              <div class="mini-metric">
+                <h4>Revenus estimés</h4>
+                <strong id="metric-income">0</strong>
+              </div>
+              <div class="mini-metric">
+                <h4>Dépenses estimées</h4>
+                <strong id="metric-expense">0</strong>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </main>
+
+    <div class="toast-container" id="player-toasts"></div>
+
+    <script src="/socket.io/socket.io.js"></script>
+    <script type="module" src="/player.js"></script>
+  </body>
+</html>

--- a/public/player.js
+++ b/public/player.js
@@ -1,0 +1,428 @@
+const els = {
+  sessionCode: document.querySelector('#player-session-code'),
+  playerTurn: document.querySelector('#player-turn'),
+  playerStatus: document.querySelector('#player-status'),
+  playerProfile: document.querySelector('#player-profile'),
+  leaveButton: document.querySelector('#leave-session'),
+  joinCard: document.querySelector('#join-card'),
+  joinForm: document.querySelector('#join-form'),
+  cards: document.querySelector('#player-common-cards'),
+  cardRefresh: document.querySelector('#player-card-refresh'),
+  notes: document.querySelector('#player-notes'),
+  timerRing: document.querySelector('#player-timer-ring'),
+  timerValue: document.querySelector('#player-timer-value'),
+  timerStatus: document.querySelector('#player-timer-status'),
+  timerProgress: document.querySelector('#player-timer-progress'),
+  actionAccept: document.querySelector('#action-accept'),
+  actionReject: document.querySelector('#action-reject'),
+  actionLock: document.querySelector('#action-lock'),
+  actionReady: document.querySelector('#action-ready'),
+  journal: document.querySelector('#player-journal'),
+  journalCount: document.querySelector('#player-journal-count'),
+  team: document.querySelector('#player-team'),
+  teamCount: document.querySelector('#player-team-count'),
+  metricDecisions: document.querySelector('#metric-decisions'),
+  metricIncome: document.querySelector('#metric-income'),
+  metricExpense: document.querySelector('#metric-expense'),
+  midgameBanner: document.querySelector('#player-midgame'),
+  toastContainer: document.querySelector('#player-toasts'),
+};
+
+let socket = null;
+let sessionCode = null;
+let playerId = null;
+let hostState = null;
+let playerState = null;
+let lastTimerTick = null;
+
+function showToast(title, message) {
+  const toast = document.createElement('div');
+  toast.className = 'toast';
+  toast.innerHTML = `<strong>${title}</strong><p>${message}</p>`;
+  els.toastContainer.appendChild(toast);
+  setTimeout(() => {
+    toast.style.opacity = '0';
+    toast.style.transform = 'translateY(6px)';
+  }, 3600);
+  setTimeout(() => toast.remove(), 4400);
+}
+
+function formatDateTime(ts) {
+  const d = new Date(ts);
+  return d.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+function formatRelative(ts) {
+  if (!ts) return '—';
+  const diff = Date.now() - ts;
+  if (diff < 5000) return 'À l'instant';
+  const min = Math.floor(diff / 60000);
+  if (min < 1) return 'Il y a quelques secondes';
+  if (min === 1) return 'Il y a 1 min';
+  if (min < 60) return `Il y a ${min} min`;
+  return `Il y a ${Math.floor(min / 60)} h`;
+}
+
+function updateTimer(now, reminderAt, endsAt) {
+  if (!reminderAt || !endsAt) {
+    els.timerValue.textContent = '--:--';
+    els.timerStatus.textContent = 'En attente du lancement';
+    els.timerRing.style.setProperty('--timer-progress', '0%');
+    els.timerProgress.style.setProperty('--progress', 0);
+    return;
+  }
+  const start = reminderAt - (3 * 60 * 1000);
+  const total = endsAt - start;
+  const remaining = Math.max(0, endsAt - now);
+  const minutes = Math.floor(remaining / 60000);
+  const seconds = Math.floor((remaining % 60000) / 1000).toString().padStart(2, '0');
+  els.timerValue.textContent = `${minutes}:${seconds}`;
+  const progress = Math.min(1, Math.max(0, (now - start) / total));
+  els.timerRing.style.setProperty('--timer-progress', `${progress * 100}%`);
+  els.timerProgress.style.setProperty('--progress', progress);
+
+  if (remaining <= 0) {
+    els.timerStatus.textContent = 'Tour terminé';
+    return;
+  }
+  if (now >= reminderAt) {
+    els.timerStatus.textContent = 'Phase de grâce';
+    els.timerRing.style.background = `conic-gradient(var(--danger) ${progress * 100}%, rgba(199,220,255,0.12) 0)`;
+  } else {
+    els.timerStatus.textContent = 'Tour en cours';
+    els.timerRing.style.background = `conic-gradient(var(--navy-300) ${progress * 100}%, rgba(199,220,255,0.12) 0)`;
+  }
+}
+
+function renderCommonCards(draw) {
+  els.cards.innerHTML = '';
+  if (!draw) {
+    const empty = document.createElement('p');
+    empty.textContent = 'En attente du prochain tirage.';
+    els.cards.appendChild(empty);
+    return;
+  }
+  Object.entries(draw).forEach(([type, card]) => {
+    const node = document.createElement('article');
+    node.className = 'common-card';
+    node.dataset.type = type;
+    const category = document.createElement('span');
+    category.className = 'category';
+    category.textContent = card.category || type;
+    const title = document.createElement('h3');
+    title.textContent = card.title;
+    const slug = document.createElement('p');
+    slug.className = 'slug';
+    slug.textContent = card.slug || '';
+    node.appendChild(category);
+    node.appendChild(title);
+    node.appendChild(slug);
+    els.cards.appendChild(node);
+  });
+}
+
+function renderJournal(journal = []) {
+  els.journal.innerHTML = '';
+  if (!journal.length) {
+    const empty = document.createElement('p');
+    empty.textContent = 'Vos actions apparaîtront ici.';
+    els.journal.appendChild(empty);
+  }
+  journal.slice().reverse().forEach(entry => {
+    const node = document.createElement('div');
+    node.className = 'timeline-entry';
+    const title = document.createElement('h4');
+    title.textContent = `${formatDateTime(entry.at)} · ${entry.type.replace('PLAYER_', '')}`;
+    const body = document.createElement('p');
+    if (entry.type === 'PLAYER_DECISION_EVENT') {
+      body.textContent = entry.decision === 'accept' ? 'Décision acceptée (revenus)' : 'Décision refusée (dépenses)';
+    } else if (entry.type === 'PLAYER_READY') {
+      body.textContent = 'Vous êtes prêt';
+    } else if (entry.type === 'PLAYER_LOCK') {
+      body.textContent = 'Décision verrouillée';
+    } else {
+      body.textContent = JSON.stringify(entry);
+    }
+    node.appendChild(title);
+    node.appendChild(body);
+    els.journal.appendChild(node);
+  });
+  els.journalCount.textContent = `${journal.length} entrée${journal.length > 1 ? 's' : ''}`;
+}
+
+function renderTeam(players = []) {
+  els.team.innerHTML = '';
+  if (!players.length) {
+    const empty = document.createElement('p');
+    empty.textContent = 'Aucun autre joueur connecté.';
+    els.team.appendChild(empty);
+  }
+  players.forEach((p, idx) => {
+    const card = document.createElement('div');
+    card.className = 'player-card';
+    if (p.id === playerId) {
+      card.style.borderColor = 'rgba(31, 111, 235, 0.55)';
+    }
+    const avatar = document.createElement('div');
+    avatar.className = 'avatar';
+    avatar.textContent = (p.profile?.name || `J${idx + 1}`).slice(0, 2).toUpperCase();
+    const info = document.createElement('div');
+    const name = document.createElement('strong');
+    name.textContent = p.profile?.name || `Joueur ${idx + 1}`;
+    name.style.display = 'block';
+    name.style.marginBottom = '4px';
+    const status = document.createElement('div');
+    status.className = 'badge-line';
+    const ready = document.createElement('span');
+    ready.className = `status-pill ${p.ready ? 'ready' : ''}`;
+    ready.textContent = p.ready ? 'Prêt' : 'En réflexion';
+    const locked = document.createElement('span');
+    locked.className = `status-pill ${p.locked ? 'locked' : ''}`;
+    locked.textContent = p.locked ? 'Verrouillé' : 'Ouvert';
+    status.appendChild(ready);
+    status.appendChild(locked);
+    info.appendChild(name);
+    info.appendChild(status);
+    const decision = document.createElement('span');
+    decision.className = 'badge';
+    decision.textContent = p.decision ? (p.decision === 'accept' ? 'Accepte' : 'Refuse') : '—';
+    info.appendChild(decision);
+    card.appendChild(avatar);
+    card.appendChild(info);
+    els.team.appendChild(card);
+  });
+  els.teamCount.textContent = `${players.length} joueur${players.length > 1 ? 's' : ''}`;
+}
+
+function updateMetrics(journal = []) {
+  const decisions = journal.filter(e => e.type === 'PLAYER_DECISION_EVENT');
+  const income = decisions.filter(e => e.decision === 'accept');
+  const expense = decisions.filter(e => e.decision === 'reject');
+  els.metricDecisions.textContent = decisions.length;
+  els.metricIncome.textContent = income.length;
+  els.metricExpense.textContent = expense.length;
+}
+
+function updateActions() {
+  const phase = hostState?.phase;
+  const you = playerState?.you;
+  const playable = phase === 'PLAY' && you;
+  els.actionAccept.disabled = !playable || you.locked;
+  els.actionReject.disabled = !playable || you.locked;
+  els.actionLock.disabled = !playable || you.locked || !you.decision;
+  els.actionReady.disabled = !playable || you.ready;
+  els.notes.disabled = !you;
+  els.leaveButton.disabled = !you;
+}
+
+function updateHeader() {
+  els.sessionCode.textContent = sessionCode || '—';
+  if (!hostState) {
+    els.playerTurn.textContent = '—';
+  } else {
+    els.playerTurn.textContent = `${hostState.turnIndex + 1} / ${hostState.totalTurns}`;
+  }
+  const you = playerState?.you;
+  if (!you) {
+    els.playerStatus.textContent = 'Hors ligne';
+    return;
+  }
+  if (hostState?.phase === 'SETUP') {
+    els.playerStatus.textContent = 'En préparation';
+  } else if (you.locked) {
+    els.playerStatus.textContent = 'Décision verrouillée';
+  } else if (you.ready) {
+    els.playerStatus.textContent = 'Prêt';
+  } else {
+    els.playerStatus.textContent = 'En réflexion';
+  }
+}
+
+function updateProfile() {
+  const name = playerState?.you?.profile?.name;
+  const key = playerState?.you?.profile?.key;
+  if (!name) {
+    els.playerProfile.textContent = 'Profil non défini';
+  } else {
+    els.playerProfile.textContent = key ? `${name} · ${key}` : name;
+  }
+}
+
+function render() {
+  updateHeader();
+  updateProfile();
+  renderCommonCards(hostState?.commonDraw || null);
+  const personalJournal = (hostState?.journal || []).filter(entry => entry.playerId === playerId);
+  renderJournal(personalJournal);
+  renderTeam(hostState?.players || []);
+  updateMetrics(personalJournal);
+  els.cardRefresh.textContent = hostState?.commonDraw ? `Mis à jour ${formatRelative(hostState.lastUpdateAt)}` : 'En attente';
+  updateActions();
+}
+
+function persistContext() {
+  if (sessionCode && playerId) {
+    localStorage.setItem('bbg-player-context', JSON.stringify({ sessionCode, playerId }));
+  }
+}
+
+function clearContext() {
+  localStorage.removeItem('bbg-player-context');
+  sessionCode = null;
+  playerId = null;
+  hostState = null;
+  playerState = null;
+  render();
+}
+
+async function refreshPlayerState() {
+  if (!sessionCode || !playerId) return;
+  try {
+    const res = await fetch(`/session/${sessionCode}/state?role=player&playerId=${playerId}`);
+    if (!res.ok) return;
+    playerState = await res.json();
+    loadNotes();
+    render();
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+function connectSocket() {
+  if (!sessionCode) return;
+  if (socket) socket.disconnect();
+  socket = io({ path: '/ws' });
+  socket.emit('JOIN_SESSION', { code: sessionCode });
+  socket.on('SESSION_UPDATED', payload => {
+    if (payload && payload.kind) {
+      showToast('Info', payload.msg || payload.kind);
+      return;
+    }
+    hostState = payload;
+    render();
+    refreshPlayerState();
+  });
+  socket.on('TIMER_TICK', data => {
+    lastTimerTick = data;
+    updateTimer(data.now, data.reminderAt, data.endsAt);
+  });
+  socket.on('TURN_STARTED', data => {
+    showToast('Nouveau tour', `Tour ${data.turn} lancé`);
+  });
+  socket.on('TURN_ENDED', data => {
+    showToast('Fin de tour', `Tour ${data.turn} terminé`);
+  });
+  socket.on('MIDGAME_BREAK', data => {
+    els.midgameBanner.classList.add('active');
+    showToast('Pause', `Tour ${data.turn}`);
+  });
+  socket.on('ERROR', data => {
+    showToast('Erreur', data.error || 'Action impossible');
+  });
+}
+
+function loadNotes() {
+  if (!sessionCode || !playerId) return;
+  const key = `bbg-notes-${sessionCode}-${playerId}`;
+  els.notes.value = localStorage.getItem(key) || '';
+}
+
+function saveNotes() {
+  if (!sessionCode || !playerId) return;
+  const key = `bbg-notes-${sessionCode}-${playerId}`;
+  localStorage.setItem(key, els.notes.value);
+}
+
+els.notes.addEventListener('input', saveNotes);
+
+els.actionAccept.addEventListener('click', () => {
+  if (!socket || !sessionCode || !playerId) return;
+  socket.emit('PLAYER_DECIDE_EVENT', { code: sessionCode, playerId, decision: 'accept' });
+  refreshPlayerState();
+});
+
+els.actionReject.addEventListener('click', () => {
+  if (!socket || !sessionCode || !playerId) return;
+  socket.emit('PLAYER_DECIDE_EVENT', { code: sessionCode, playerId, decision: 'reject' });
+  refreshPlayerState();
+});
+
+els.actionLock.addEventListener('click', () => {
+  if (!socket || !sessionCode || !playerId) return;
+  socket.emit('PLAYER_LOCK', { code: sessionCode, playerId });
+  refreshPlayerState();
+});
+
+els.actionReady.addEventListener('click', () => {
+  if (!socket || !sessionCode || !playerId) return;
+  socket.emit('PLAYER_READY', { code: sessionCode, playerId });
+  refreshPlayerState();
+});
+
+els.leaveButton.addEventListener('click', () => {
+  clearContext();
+  els.joinCard.style.display = 'block';
+  els.joinForm.reset();
+  els.notes.value = '';
+  if (socket) socket.disconnect();
+  showToast('Session quittée', 'Vous pouvez rejoindre une nouvelle partie.');
+});
+
+els.joinForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const form = new FormData(event.currentTarget);
+  const code = (form.get('code') || '').trim().toUpperCase();
+  const name = (form.get('name') || '').trim();
+  if (!code) return;
+  try {
+    const res = await fetch(`/session/${code}/join`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ profile: name ? { name } : undefined }),
+    });
+    if (!res.ok) {
+      const payload = await res.json().catch(() => ({}));
+      throw new Error(payload.error || 'Impossible de rejoindre la session');
+    }
+    const json = await res.json();
+    sessionCode = code;
+    playerId = json.playerId;
+    persistContext();
+    els.joinCard.style.display = 'none';
+    connectSocket();
+    await refreshPlayerState();
+    showToast('Bienvenue', `Vous avez rejoint la session ${code}`);
+  } catch (err) {
+    showToast('Erreur', err.message);
+  }
+});
+
+function tryRestoreContext() {
+  try {
+    const raw = localStorage.getItem('bbg-player-context');
+    if (!raw) return;
+    const parsed = JSON.parse(raw);
+    if (parsed.sessionCode && parsed.playerId) {
+      sessionCode = parsed.sessionCode;
+      playerId = parsed.playerId;
+      els.joinCard.style.display = 'none';
+      connectSocket();
+      refreshPlayerState();
+      showToast('Reconnecté', `Session ${sessionCode}`);
+    }
+  } catch (err) {
+    console.warn('Unable to restore context', err);
+  }
+}
+
+setInterval(() => {
+  if (lastTimerTick) {
+    updateTimer(Date.now(), lastTimerTick.reminderAt, lastTimerTick.endsAt);
+  }
+  if (hostState) {
+    els.cardRefresh.textContent = hostState.commonDraw ? `Mis à jour ${formatRelative(hostState.lastUpdateAt)}` : 'En attente';
+  }
+}, 5000);
+
+tryRestoreContext();
+render();

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,601 @@
+:root {
+  --navy-900: #071533;
+  --navy-700: #0a1f44;
+  --navy-500: #123d8f;
+  --navy-300: #1f6feb;
+  --sky-100: #c7dcff;
+  --sand-100: #f3f5f9;
+  --neutral-100: #ffffff;
+  --neutral-200: #e4e8f1;
+  --neutral-400: #99a1b5;
+  --success: #22b07d;
+  --warning: #f6a609;
+  --danger: #ff5c5c;
+  --font-sans: 'Inter', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  background: linear-gradient(135deg, rgba(7, 21, 51, 0.94), rgba(10, 31, 68, 0.88)), url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160"><g fill="none" fill-opacity="0.12" stroke="%23FFFFFF" stroke-width="1"><path d="M0 0h160v160H0z"/><path d="M40 0v160M80 0v160M120 0v160M0 40h160M0 80h160M0 120h160"/></g></svg>');
+  background-size: cover;
+  color: var(--sand-100);
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+}
+
+button,
+input,
+select,
+textarea {
+  font-family: inherit;
+}
+
+main {
+  padding: 24px clamp(24px, 4vw, 64px);
+}
+
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: blur(16px);
+  background: rgba(7, 21, 51, 0.75);
+  border-bottom: 1px solid rgba(199, 220, 255, 0.1);
+  padding: 16px clamp(24px, 4vw, 64px);
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  justify-content: space-between;
+}
+
+.header__title {
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  margin: 0;
+}
+
+.header__meta {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  color: var(--sky-100);
+  font-size: 0.95rem;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 99px;
+  background: rgba(31, 111, 235, 0.15);
+  color: var(--sky-100);
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 360px minmax(420px, 1fr) 360px;
+  gap: 24px;
+}
+
+.card {
+  background: rgba(10, 31, 68, 0.78);
+  border: 1px solid rgba(31, 111, 235, 0.24);
+  border-radius: 18px;
+  padding: 20px;
+  box-shadow: 0 14px 24px rgba(0, 20, 68, 0.35);
+}
+
+.card h2,
+.card h3 {
+  margin-top: 0;
+  color: var(--sky-100);
+}
+
+.card + .card {
+  margin-top: 16px;
+}
+
+.section-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.section-title h2 {
+  font-size: 1.05rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.section-title .chip {
+  font-size: 0.8rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.form-grid label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.85rem;
+  color: var(--sky-100);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.form-grid input,
+.form-grid select,
+.form-grid button {
+  margin-top: 6px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(199, 220, 255, 0.2);
+  background: rgba(7, 21, 51, 0.62);
+  color: var(--sand-100);
+}
+
+button.primary {
+  background: linear-gradient(120deg, var(--navy-500), var(--navy-300));
+  border: none;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button.primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(31, 111, 235, 0.25);
+}
+
+button.secondary {
+  background: rgba(31, 111, 235, 0.18);
+  border: 1px solid rgba(199, 220, 255, 0.24);
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+button.secondary:hover {
+  background: rgba(31, 111, 235, 0.28);
+}
+
+button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.player-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.player-card {
+  background: rgba(7, 21, 51, 0.6);
+  border: 1px solid rgba(199, 220, 255, 0.12);
+  border-radius: 14px;
+  padding: 12px 14px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 12px;
+  align-items: center;
+}
+
+.player-card .avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: rgba(31, 111, 235, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.player-card .status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 9px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  background: rgba(199, 220, 255, 0.12);
+  color: var(--sky-100);
+}
+
+.player-card .status-pill.ready {
+  background: rgba(34, 176, 125, 0.2);
+  color: #9ef3cf;
+}
+
+.player-card .status-pill.locked {
+  background: rgba(255, 92, 92, 0.18);
+  color: #ffc1c1;
+}
+
+.player-analytics {
+  display: grid;
+  gap: 8px;
+}
+
+.badge-line {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.badge-line .badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: 12px;
+  font-size: 0.7rem;
+  background: rgba(199, 220, 255, 0.1);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.badge.active {
+  background: rgba(31, 111, 235, 0.32);
+  color: var(--neutral-100);
+}
+
+.sparkline {
+  width: 140px;
+  height: 44px;
+  border-radius: 12px;
+  background: rgba(7, 21, 51, 0.75);
+  border: 1px solid rgba(31, 111, 235, 0.2);
+}
+
+.timer-panel {
+  position: relative;
+  padding: 24px;
+  border-radius: 20px;
+  background: linear-gradient(145deg, rgba(7, 21, 51, 0.8), rgba(18, 61, 143, 0.7));
+  overflow: hidden;
+}
+
+.timer-ring {
+  width: 140px;
+  height: 140px;
+  border-radius: 50%;
+  background: conic-gradient(var(--navy-300) var(--timer-progress, 0%), rgba(199, 220, 255, 0.12) 0);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 16px;
+}
+
+.timer-ring span {
+  font-size: 1.6rem;
+  font-weight: 600;
+}
+
+.timer-panel p {
+  text-align: center;
+  color: var(--sky-100);
+  margin: 0;
+}
+
+.cards-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.common-card {
+  background: rgba(7, 21, 51, 0.65);
+  border: 1px solid rgba(199, 220, 255, 0.16);
+  border-left: 4px solid var(--navy-300);
+  border-radius: 16px;
+  padding: 16px;
+  display: grid;
+  gap: 6px;
+  min-height: 120px;
+}
+
+.common-card[data-type="bonus"] { border-left-color: #2ecc71; }
+.common-card[data-type="contrainte"] { border-left-color: #ff6b6b; }
+.common-card[data-type="evenement"] { border-left-color: #4ba3ff; }
+
+.common-card h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.common-card .category {
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--neutral-200);
+}
+
+.common-card .slug {
+  font-size: 0.85rem;
+  color: var(--neutral-200);
+}
+
+.timeline {
+  max-height: 380px;
+  overflow: auto;
+  padding-right: 4px;
+  display: grid;
+  gap: 12px;
+}
+
+.timeline-entry {
+  background: rgba(7, 21, 51, 0.6);
+  border-radius: 14px;
+  padding: 12px;
+  border-left: 3px solid rgba(31, 111, 235, 0.3);
+}
+
+.timeline-entry h4 {
+  margin: 0 0 6px 0;
+  font-size: 0.9rem;
+  color: var(--neutral-200);
+}
+
+.timeline-entry p {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.toast-container {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  display: grid;
+  gap: 12px;
+  z-index: 100;
+}
+
+.toast {
+  background: rgba(7, 21, 51, 0.88);
+  border: 1px solid rgba(31, 111, 235, 0.3);
+  border-radius: 14px;
+  padding: 12px 16px;
+  min-width: 220px;
+  box-shadow: 0 10px 18px rgba(7, 21, 51, 0.45);
+}
+
+.toast strong {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--neutral-100);
+}
+
+.toast p {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--neutral-200);
+}
+
+.progress-bar {
+  position: relative;
+  width: 100%;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(199, 220, 255, 0.12);
+  overflow: hidden;
+}
+
+.progress-bar span {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  transform-origin: left;
+  transform: scaleX(var(--progress, 0));
+  background: linear-gradient(90deg, var(--navy-300), var(--navy-500));
+  transition: transform 0.4s ease;
+}
+
+.midgame-banner {
+  display: none;
+  padding: 14px 18px;
+  border-radius: 12px;
+  background: rgba(246, 166, 9, 0.18);
+  border: 1px solid rgba(246, 166, 9, 0.45);
+  color: #ffd48a;
+  font-size: 0.9rem;
+  margin-bottom: 16px;
+}
+
+.midgame-banner.active {
+  display: block;
+}
+
+.tab-group {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.tab-group button {
+  flex: 1;
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(199, 220, 255, 0.18);
+  background: rgba(7, 21, 51, 0.45);
+  color: var(--neutral-200);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.tab-group button.active {
+  background: rgba(31, 111, 235, 0.25);
+  color: var(--neutral-100);
+}
+
+.details-panel {
+  display: none;
+  gap: 16px;
+}
+
+.details-panel.active {
+  display: grid;
+}
+
+.details-panel textarea {
+  width: 100%;
+  min-height: 120px;
+  border-radius: 12px;
+  border: 1px solid rgba(199, 220, 255, 0.16);
+  background: rgba(7, 21, 51, 0.55);
+  color: var(--neutral-100);
+  padding: 12px;
+}
+
+.timeline-small {
+  display: grid;
+  gap: 10px;
+  max-height: 260px;
+  overflow: auto;
+}
+
+.timeline-small .item {
+  background: rgba(7, 21, 51, 0.55);
+  border-radius: 12px;
+  padding: 10px;
+  border-left: 3px solid rgba(31, 111, 235, 0.24);
+}
+
+.timeline-small .item h4 {
+  margin: 0 0 4px 0;
+  font-size: 0.82rem;
+}
+
+.timeline-small .item p {
+  margin: 0;
+  font-size: 0.76rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.mini-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.mini-metric {
+  background: rgba(7, 21, 51, 0.55);
+  border-radius: 12px;
+  padding: 12px;
+  border: 1px solid rgba(31, 111, 235, 0.15);
+}
+
+.mini-metric h4 {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--neutral-200);
+}
+
+.mini-metric strong {
+  display: block;
+  margin-top: 6px;
+  font-size: 1.1rem;
+}
+
+.player-action-bar {
+  display: grid;
+  gap: 12px;
+}
+
+.player-action-bar button {
+  padding: 12px;
+  border-radius: 14px;
+  border: none;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.player-action-bar button.accept {
+  background: linear-gradient(120deg, rgba(46, 204, 113, 0.75), rgba(12, 148, 86, 0.9));
+  color: #e9fff4;
+}
+
+.player-action-bar button.reject {
+  background: linear-gradient(120deg, rgba(255, 107, 107, 0.75), rgba(193, 49, 72, 0.9));
+  color: #ffecec;
+}
+
+.player-action-bar button.lock {
+  background: rgba(31, 111, 235, 0.38);
+  color: var(--neutral-100);
+}
+
+.note-area textarea {
+  width: 100%;
+  min-height: 120px;
+  border-radius: 12px;
+  border: 1px solid rgba(31, 111, 235, 0.18);
+  background: rgba(7, 21, 51, 0.52);
+  color: var(--neutral-100);
+  padding: 12px;
+}
+
+.profile-strip {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.profile-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(31, 111, 235, 0.22);
+  background: rgba(7, 21, 51, 0.52);
+}
+
+@media (max-width: 1280px) {
+  .layout {
+    grid-template-columns: 320px 1fr;
+    grid-template-areas:
+      'left center'
+      'right right';
+  }
+  .layout > .column:nth-child(1) { grid-area: left; }
+  .layout > .column:nth-child(2) { grid-area: center; }
+  .layout > .column:nth-child(3) { grid-area: right; }
+}
+
+@media (max-width: 960px) {
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  main {
+    padding: 16px;
+  }
+  .header {
+    padding: 16px;
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,6 +1,7 @@
 // server/server.js
 const express = require('express');
 const http = require('http');
+const path = require('path');
 const cors = require('cors');
 const { Server } = require('socket.io');
 
@@ -23,6 +24,8 @@ const ALLOWED_ORIGINS = (process.env.CORS_ORIGINS || '').split(',').filter(Boole
       return cb(new Error('Not allowed by CORS'), false);
     },
   }));
+  const publicDir = path.join(__dirname, '..', 'public');
+  app.use(express.static(publicDir));
 
   const decks = loadAll(process.env.DATA_DIR || 'data');
   const store = new SessionStore();
@@ -134,6 +137,18 @@ const ALLOWED_ORIGINS = (process.env.CORS_ORIGINS || '').split(',').filter(Boole
   }
 
   app.get('/health', (_, res) => res.status(200).send('OK'));
+
+  app.get('/', (_, res) => {
+    res.sendFile(path.join(publicDir, 'host.html'));
+  });
+
+  app.get('/host', (_, res) => {
+    res.sendFile(path.join(publicDir, 'host.html'));
+  });
+
+  app.get('/player', (_, res) => {
+    res.sendFile(path.join(publicDir, 'player.html'));
+  });
 
   app.post('/session', (req, res) => {
     try {


### PR DESCRIPTION
## Summary
- serve static front-end assets from Express with friendly host and player routes
- design desktop-first host control room with live cards, timers, analytics and notifications
- implement immersive player console featuring decision actions, journal, team status and private notes

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68d2901d0ba483289e8bfaed4de1c669